### PR TITLE
Update Dockerfile

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bullseye
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libmagic1 python3-pip \
+    && apt-get install -y --no-install-recommends libmagic1 python3-pip gcc python3-dev\
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV USER="jupyter"


### PR DESCRIPTION
Add gcc and python3-dev to Dockerfile due to error when runnng "build". Might not be the best solution but I got this error:

```
psutil could not be installed from sources because gcc is not installed. Try running:
15.13     sudo apt-get install gcc python3-dev
15.13   error: command 'aarch64-linux-gnu-gcc' failed: No such file or directory
```
The current solution doesn't work on MacOS M2 (aarch64).